### PR TITLE
Cross-platform build support and logging fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,11 @@ RUN go mod download
 
 FROM build_deps AS build
 
+ARG GOARCH=amd64
+
 COPY . .
 
-RUN CGO_ENABLED=0 go build -o webhook -ldflags '-w -extldflags "-static"' .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH="$GOARCH" go build -o webhook -ldflags '-w -extldflags "-static"' .
 
 FROM scratch
 

--- a/deploy/cert-manager-webhook-linode/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-linode/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --tls-cert-file=/tls/tls.crt
             - --tls-private-key-file=/tls/tls.key
 {{- if .Values.deployment.logLevel }}
-            - --v={{ .Values.deployment.logLevel }}
+            - -v={{ .Values.deployment.logLevel }}
 {{- end }}
           env:
             - name: GROUP_NAME

--- a/deploy/cert-manager-webhook-linode/templates/rbac.yaml
+++ b/deploy/cert-manager-webhook-linode/templates/rbac.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: {{ include "cert-manager-webhook-linode.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.deployment.imagePullSecret }}
+imagePullSecrets:
+  - name: {{ .Values.deployment.imagePullSecret }}
+{{- end }}
 ---
 # Grant the webhook permission to read the ConfigMap containing the Kubernetes
 # apiserver's requestheader-ca-certificate.

--- a/deploy/cert-manager-webhook-linode/templates/rbac.yaml
+++ b/deploy/cert-manager-webhook-linode/templates/rbac.yaml
@@ -94,6 +94,45 @@ subjects:
     name: {{ .Values.certManager.serviceAccountName }}
     namespace: {{ .Values.certManager.namespace | quote }}
 ---
+# Grant cert-manager permission to validate using our apiserver
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "cert-manager-webhook-linode.fullname" . }}:flow-control
+  labels:
+    app: {{ include "cert-manager-webhook-linode.name" . }}
+    chart: {{ include "cert-manager-webhook-linode.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups:
+      - flowcontrol.apiserver.k8s.io
+    resources:
+      - "flowschemas"
+      - "prioritylevelconfigurations"
+    verbs:
+      - "list"
+      - "watch"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "cert-manager-webhook-linode.fullname" . }}:flow-control
+  labels:
+    app: {{ include "cert-manager-webhook-linode.name" . }}
+    chart: {{ include "cert-manager-webhook-linode.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "cert-manager-webhook-linode.fullname" . }}:flow-control
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ include "cert-manager-webhook-linode.fullname" . }}
+    namespace: {{ .Values.certManager.namespace | quote }}
+---
 # Grant the webhook permission to read the Secret containing the Linode API token
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/deploy/cert-manager-webhook-linode/values.yaml
+++ b/deploy/cert-manager-webhook-linode/values.yaml
@@ -17,6 +17,7 @@ deployment:
   secretName: linode-credentials
   secretKey: token
   logLevel: 6
+  imagePullSecret: ""
 
 image:
   repository: slicen/cert-manager-webhook-linode

--- a/main.go
+++ b/main.go
@@ -40,6 +40,8 @@ func main() {
 		panic("GROUP_NAME must be specified")
 	}
 
+	klog.InitFlags(nil)
+
 	// This will register our external-dns DNS provider with the webhook serving
 	// library, making it available as an API under the provided GroupName.
 	// You can register multiple DNS provider implementations with a single


### PR DESCRIPTION
This PR includes a few fixes for cert-manager-webhook-linode, namely:

* Support for cross-platform image builds using `GOARCH`
* Support for private image repositories using image pull secrets, configurable using `deployment.imagePullSecret`
* RBAC fixes to allow webhook to use [API Priority and Fairness](https://kubernetes.io/docs/concepts/cluster-administration/flow-control/)
* Fixes for leveled logging (fixes #5)